### PR TITLE
Typedloaddep

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sudo pip3 install spidev
 
 ### RadioPi Dependencies
 ```shell script
-sudo apt-get install python-alsaaudio
+sudo apt-get install python-alsaaudio python3-typedload
 sudo pip3 install flask
 sudo pip3 install flask-socketio 
 ```

--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ Details on the SSD1305 display can be found here: http://www.waveshare.com/wiki/
 To install the SSD1305 drivers on the raspberry pi you should run:
 ```shell script
 sudo apt-get update
-sudo apt-get install python3-pip
-sudo apt-get install python3-pil
-sudo apt-get install python3-numpy
+sudo apt-get install python3-pip python3-pil python3-numpy
 sudo pip3 install RPi.GPIO
 sudo pip3 install spidev
 ```


### PR DESCRIPTION
Dependency on typedload isn't listed.

I would also not use pip and just install all the modules via apt, so they remain up to date with the system. But I felt that's something you have to decide.