### PR TITLE
Fix import

### DIFF
--- a/Clock.py
+++ b/Clock.py
@@ -4,7 +4,7 @@ from enum import Enum
 from json.decoder import JSONDecodeError
 from typing import NamedTuple, List
 
-import typedload as typedload
+import typedload
 
 
 class AlarmType(Enum):


### PR DESCRIPTION
The `as` part is not needed since it's renamed to the same thing.