### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+numpy
+RPi.GPIO
+spidev
+typedload
+pyalsaaudio
+flask
+flask-socketio


### PR DESCRIPTION
I added the stuff from the README, feel free to change if I did some mistake.

requirements.txt is so that one can just install everything with pip directly, passing the
requirements file.